### PR TITLE
Adding issue write permissions to the triage action

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@v3.0
       with:


### PR DESCRIPTION
The triage action has been failing to label issues. I think this is due
to missing the permission to write to issues.

