### PR TITLE
Add `Not` verifier for negating verifier results

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -397,6 +397,7 @@ impl<E: DisplayableError> Display for NotError<E> {
             .finish()
     }
 }
+
 /// Will negate the result of the [`Verifier::verify()`] operation.
 #[derive(Debug)]
 pub struct Not<V> {
@@ -663,7 +664,7 @@ mod tests {
             "Forced failure via `AlwaysFalse`"
         );
     }
-    
+
     #[test]
     fn not_negates_success() {
         let not = Not::new(AlwaysTrue);


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

