### PR TITLE
Update `ReportDataVerifier` to use a mask

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -86,12 +86,14 @@ pub enum VerificationError {
         /// The actual measurement that was present
         actual: MrSigner,
     },
-    /// The report data did not match expected:{expected:?} actual:{actual:?}
+    /// The report data did not match expected:{expected:?} actual:{actual:?} mask:{mask:?}
     ReportDataMismatch {
         /// The expected report data
         expected: ReportData,
         /// The actual report data that was present
         actual: ReportData,
+        /// Mask of which bytes were expected to match
+        mask: ReportData,
     },
 }
 


### PR DESCRIPTION
Previously `ReportDataVerifier` compared all of the bytes in the `ReportData`. Now callers can specify a bitmask of bits that will be compared between the actual and expected values.
