### PR TITLE
Update `MrSignerVerifier` to verify necessary sub components

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -109,11 +109,11 @@ pub enum VerificationError {
         /// The actual measurement that was present
         actual: MrEnclave,
     },
-    /// The MRSIGNER measurement did not match expected:{expected:?} actual:{actual:?}
-    MrSignerMismatch {
-        /// The expected measurement
+    /// The MRSIGNER key did not match expected:{expected:?} actual:{actual:?}
+    MrSignerKeyMismatch {
+        /// The expected key
         expected: MrSigner,
-        /// The actual measurement that was present
+        /// The actual key that was present
         actual: MrSigner,
     },
     /// The report data did not match expected:{expected:?} actual:{actual:?} mask:{mask:?}


### PR DESCRIPTION
Previously the `MrSignerVerifier` only verified the key, or
measurement. Now `MrSignerVerifier` verifies the key, product id and
svn. This matches the "Security Enclave Modification Policy".

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

