### PR TITLE
Add a displyable result for `MrSignerVerifier`

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -91,7 +91,7 @@ pub trait ResultMessage {
 }
 
 /// Failed to verify.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub enum VerificationResultMetadata {
     /// Generic no extra info.
     General,


### PR DESCRIPTION
Previously `MrSignerVerifier` was using the
`VerificationResultMetadata::General` losing the details of what failed
during `MrSignerVerifier::verify()`. Now a dedicated
`MrSignerVerificationMetadata` is used to persist all of the
verification information.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

