### PR TITLE
Add `VerificationTreeDisplay`

### DIFF
--- a/verifier/src/struct_name.rs
+++ b/verifier/src/struct_name.rs
@@ -40,4 +40,6 @@ spaced_struct_name! {
     ConfigSvn, "config SVN";
     FamilyId, "family ID";
     ReportData, "report data";
+    u8, "Unsigned byte";
+
 }


### PR DESCRIPTION
The `VerificationTreeDisplay` allows one to display the output of a
verification, showing which phases succeeded, which failed and what the
values were for each phase.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

