### PR TITLE
Update settings.yml file to propagate branch settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -82,7 +82,8 @@ branches:
     protection:
       required_pull_request_reviews:
         require_code_owner_reviews: true
-        required_approving_review_count: 1
+        required_approving_review_count: 2
+        dismissal_restrictions: null
       required_conversation_resolution: true
       required_status_checks:
         strict: false


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

The branch settings aren't propagating, looking at https://github.com/repository-settings/app/issues/267 and the example settings at https://github.com/apps/settings it seems that these can be kind of finicky.

This change(attempt) added the `dismissal_restrictions` setting to the file since the example calls out to set it to null in organization repos, but remove for personal repos.  Most of our testing was done in personal repos so looking here first.
