### PR TITLE
Move x509 cert logic to sub-directory

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -4,19 +4,16 @@
 #![deny(missing_docs, missing_debug_implementations, unsafe_code)]
 #![no_std]
 
-#[cfg(feature = "alloc")]
-mod certs;
 mod report_body;
 mod struct_name;
+#[cfg(feature = "alloc")]
+mod x509;
 
 pub use report_body::{
     AttributesVerifier, ConfigIdVerifier, ConfigSvnVerifier, CpuSvnVerifier,
     ExtendedProductIdVerifier, FamilyIdVerifier, IsvProductIdVerifier, IsvSvnVerifier,
     MiscellaneousSelectVerifier, MrEnclaveVerifier, MrSignerVerifier, ReportDataVerifier,
 };
-
-#[cfg(feature = "alloc")]
-pub use certs::{Error as CertificateError, UnverifiedCertificate, VerifiedCertificate};
 
 use core::fmt::{Debug, Display, Formatter};
 use mc_sgx_core_types::{

--- a/verifier/src/x509.rs
+++ b/verifier/src/x509.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2023 The MobileCoin Foundation
+
+// TODO: Remove dead_code exception once this is connected up to the rest of the codebase
+#![allow(dead_code)]
+mod certs;
+mod error;
+
+pub use error::Error;
+pub type Result<T> = core::result::Result<T, Error>;

--- a/verifier/src/x509/certs.rs
+++ b/verifier/src/x509/certs.rs
@@ -2,6 +2,7 @@
 
 //! Verifier(s) for [`CertificationData`](`mc-sgx-dcap-types::CertificationData`).
 
+use super::{Error, Result};
 use core::time::Duration;
 use p256::ecdsa::signature::Verifier;
 use p256::ecdsa::{Signature, VerifyingKey};
@@ -11,31 +12,6 @@ use x509_cert::Certificate as X509Certificate;
 /// Offset from the start of a certificate to the "to be signed" (TBS) portion
 /// of the certificate.
 const TBS_OFFSET: usize = 4;
-
-pub type Result<T> = core::result::Result<T, Error>;
-
-/// Error type for decoding and verifying certificates.
-#[derive(Debug, displaydoc::Display, PartialEq, Eq)]
-pub enum Error {
-    /// An error occurred decoding the signature from a certificate
-    SignatureDecoding,
-    /// The certification signature does not match with the verifying key
-    SignatureVerification,
-    /// The certificate has expired
-    CertificateExpired,
-    /// An error occurred decoding the certificate
-    CertificateDecoding(x509_cert::der::Error),
-    /// The certificate is not yet valid
-    CertificateNotYetValid,
-    /// An error occurred decoding the key from a certificate
-    KeyDecoding,
-}
-
-impl From<x509_cert::der::Error> for Error {
-    fn from(src: x509_cert::der::Error) -> Self {
-        Error::CertificateDecoding(src)
-    }
-}
 
 /// A certificate whose signature has not been verified.
 #[derive(Debug, PartialEq, Eq)]
@@ -152,9 +128,9 @@ mod test {
     use const_oid::ObjectIdentifier;
     use yare::parameterized;
 
-    const LEAF_CERT: &str = include_str!("../data/tests/leaf_cert.pem");
-    const INTERMEDIATE_CA: &str = include_str!("../data/tests/intermediate_ca.pem");
-    const ROOT_CA: &str = include_str!("../data/tests/root_ca.pem");
+    const LEAF_CERT: &str = include_str!("../../data/tests/leaf_cert.pem");
+    const INTERMEDIATE_CA: &str = include_str!("../../data/tests/intermediate_ca.pem");
+    const ROOT_CA: &str = include_str!("../../data/tests/root_ca.pem");
 
     #[parameterized(
         root = { ROOT_CA },

--- a/verifier/src/x509/error.rs
+++ b/verifier/src/x509/error.rs
@@ -1,0 +1,22 @@
+/// Error type for decoding and verifying certificates.
+#[derive(Debug, displaydoc::Display, PartialEq, Eq)]
+pub enum Error {
+    /// An error occurred decoding the signature from a certificate
+    SignatureDecoding,
+    /// The certification signature does not match with the verifying key
+    SignatureVerification,
+    /// The certificate has expired
+    CertificateExpired,
+    /// An error occurred decoding the certificate
+    CertificateDecoding(x509_cert::der::Error),
+    /// The certificate is not yet valid
+    CertificateNotYetValid,
+    /// An error occurred decoding the key from a certificate
+    KeyDecoding,
+}
+
+impl From<x509_cert::der::Error> for Error {
+    fn from(src: x509_cert::der::Error) -> Self {
+        Error::CertificateDecoding(src)
+    }
+}


### PR DESCRIPTION
The x509 certificate logic has been moved to a dedicated sub-directory
to better group the coming CRL and certificate chain logic.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
