### PR TITLE
Allow merge commits

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,7 @@ repository:
   has_downloads: false
   default_branch: main
   allow_squash_merge: true
-  allow_merge_commit: false
+  allow_merge_commit: true
   allow_rebase_merge: false
   allow_auto_merge: true
   delete_branch_on_merge: true
@@ -119,5 +119,4 @@ branches:
           - "test (stable)"
           - coverage
       enforce_admins: true
-      required_linear_history: true
       restrictions: null


### PR DESCRIPTION
Previously merge commits were disallowed. When using stacked PRs, if the
initial PR uses a squash merge, git and github loose the information to
associate the initial commits in subsequent PRs as belonging to the
initial PR. This results in github saying there are merge conflicts.
Using merge commits allows github to better keep track of which commits
are unique to each PR.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
