### PR TITLE
Make PKITS test support functions more ergonomic.

### DIFF
--- a/verifier/tests/common/mod.rs
+++ b/verifier/tests/common/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 The MobileCoin Foundation
 
-use mc_attestation_verifier::x509::{CertificateChain, PublicKey, UnverifiedCrl};
+use mc_attestation_verifier::x509::{
+    CertificateChain, PublicKey, UnverifiedCrl, VerifiedCertificate,
+};
 use std::time::Duration;
 use x509_cert::crl::CertificateList;
 use x509_cert::der::Decode;
@@ -14,10 +16,14 @@ pub const TRUST_ANCHOR_ROOT_CRL: &[u8] =
 pub const GOOD_CA_CRL: &[u8] = include_bytes!("../data/pkits/crls/GoodCACRL.crl");
 
 /// Create a certificate chain and extract the key from the leaf certificate.
-pub fn chain_and_leaf_key(certs: &[&[u8]]) -> (CertificateChain, PublicKey) {
-    let chain = CertificateChain::try_from(certs).expect("Failed decoding certs");
+///
+/// # Arguments
+///
+/// * `der_certs` - DER-encoded certificates in order from root to leaf
+pub fn chain_and_leaf_key<const N: usize>(der_certs: &[&[u8]; N]) -> (CertificateChain, PublicKey) {
+    let chain = CertificateChain::try_from(der_certs.as_slice()).expect("Failed decoding certs");
 
-    let leaf_der = certs.last().expect("Should be at least one cert");
+    let leaf_der = der_certs.last().expect("Should be at least one cert");
     let leaf_cert = X509Certificate::from_der(leaf_der).expect("Failed decoding DER");
     let key = PublicKey::try_from(&leaf_cert.tbs_certificate.subject_public_key_info)
         .expect("Failed decoding key");
@@ -25,10 +31,14 @@ pub fn chain_and_leaf_key(certs: &[&[u8]]) -> (CertificateChain, PublicKey) {
     (chain, key)
 }
 
-/// Create a list CRLs and extract the time from the last CRL.
+/// Create a list of [`UnverifiedCrl`]s and extract the time from the last CRL.
 ///
 /// The last CRL's time usually has the narrowest validity window.
-pub fn crls_and_time(der_crls: &[&[u8]]) -> (Vec<UnverifiedCrl>, Duration) {
+///
+/// # Arguments
+///
+/// * `der_crls` - DER-encoded CRLs in order from root to leaf
+pub fn crls_and_time<const N: usize>(der_crls: &[&[u8]; N]) -> (Vec<UnverifiedCrl>, Duration) {
     let crls = der_crls
         .iter()
         .map(|crl| UnverifiedCrl::try_from(*crl).expect("Failed decoding CRL"))
@@ -44,4 +54,11 @@ pub fn crls_and_time(der_crls: &[&[u8]]) -> (Vec<UnverifiedCrl>, Duration) {
 
     let unix_time = next_update - Duration::from_nanos(1);
     (crls, unix_time)
+}
+
+/// Get the [`VerifiedCertificate`] for the root/trust anchor of the chain.
+pub fn verified_root(chain: &CertificateChain, unix_time: Duration) -> VerifiedCertificate {
+    chain.as_ref()[0]
+        .verify_self_signed(unix_time)
+        .expect("Failed verifying root")
 }

--- a/verifier/tests/pkits-4-1.rs
+++ b/verifier/tests/pkits-4-1.rs
@@ -21,19 +21,13 @@ const INVALID_EE_SIGNATURE_TEST_3EE: &[u8] =
 
 #[test]
 fn valid_signatures_test_4_1_1() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_CERTIFICATE_PATH_TEST_1EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_CERTIFICATE_PATH_TEST_1EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -60,19 +54,13 @@ fn invalid_ca_signature_test_4_1_2() {
 
 #[test]
 fn invalid_ee_signature_test_4_1_3() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            INVALID_EE_SIGNATURE_TEST_3EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        INVALID_EE_SIGNATURE_TEST_3EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),

--- a/verifier/tests/pkits-4-2.rs
+++ b/verifier/tests/pkits-4-2.rs
@@ -39,20 +39,14 @@ const BAD_NOT_AFTER_DATE_CA_CRL: &[u8] = include_bytes!("data/pkits/crls/BadnotA
 
 #[test]
 fn invalid_ca_not_before_date_4_2_1() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            BAD_NOT_BEFORE_DATE_CA_CERT,
-            INVALID_CA_NOT_BEFORE_DATE_TEST_1EE,
-        ]
-        .as_slice(),
-    );
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        BAD_NOT_BEFORE_DATE_CA_CERT,
+        INVALID_CA_NOT_BEFORE_DATE_TEST_1EE,
+    ]);
     let (crls, unix_time) =
-        common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, BAD_NOT_BEFORE_DATE_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+        common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, BAD_NOT_BEFORE_DATE_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -62,19 +56,13 @@ fn invalid_ca_not_before_date_4_2_1() {
 
 #[test]
 fn invalid_ee_not_before_date_4_2_2() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            INVALID_EE_NOT_BEFORE_DATE_TEST_2EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        INVALID_EE_NOT_BEFORE_DATE_TEST_2EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -171,19 +159,13 @@ fn valid_pre2000_utc_before_date_4_2_3() {
 
 #[test]
 fn valid_generalizedtime_before_date_4_2_4() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_GENERALIZED_TIME_NOT_BEFORE_DATE_TEST_4EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_GENERALIZED_TIME_NOT_BEFORE_DATE_TEST_4EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -194,20 +176,14 @@ fn valid_generalizedtime_before_date_4_2_4() {
 
 #[test]
 fn invalid_ca_not_after_date_4_2_5() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            BAD_NOT_AFTER_DATE_CA_CERT,
-            INVALID_CA_NOT_AFTER_DATE_TEST_5EE,
-        ]
-        .as_slice(),
-    );
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        BAD_NOT_AFTER_DATE_CA_CERT,
+        INVALID_CA_NOT_AFTER_DATE_TEST_5EE,
+    ]);
     let (crls, unix_time) =
-        common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, BAD_NOT_AFTER_DATE_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+        common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, BAD_NOT_AFTER_DATE_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -217,19 +193,13 @@ fn invalid_ca_not_after_date_4_2_5() {
 
 #[test]
 fn invalid_ee_not_after_date_4_2_6() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            INVALID_EE_NOT_AFTER_DATE_TEST_6EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        INVALID_EE_NOT_AFTER_DATE_TEST_6EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -239,19 +209,13 @@ fn invalid_ee_not_after_date_4_2_6() {
 
 #[test]
 fn invalid_pre_2000_utc_ee_not_after_date_4_2_7() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            INVALID_PRE_2000_UTC_EE_NOT_AFTER_DATE_TEST_7EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        INVALID_PRE_2000_UTC_EE_NOT_AFTER_DATE_TEST_7EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -261,19 +225,13 @@ fn invalid_pre_2000_utc_ee_not_after_date_4_2_7() {
 
 #[test]
 fn valid_generalized_time_after_date_4_2_8() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_GENERALIZED_TIME_NOT_AFTER_DATE_TEST_8EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_GENERALIZED_TIME_NOT_AFTER_DATE_TEST_8EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())

--- a/verifier/tests/pkits-4-3.rs
+++ b/verifier/tests/pkits-4-3.rs
@@ -56,19 +56,13 @@ const UTF8_STRING_CASE_INSENSITIVE_MATCH_CA_CRL: &[u8] =
 
 #[test]
 fn invalid_name_chaining_ee_4_3_1() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            INVALID_NAME_CHAINING_TEST_1EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        INVALID_NAME_CHAINING_TEST_1EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -78,20 +72,13 @@ fn invalid_name_chaining_ee_4_3_1() {
 
 #[test]
 fn invalid_name_chaining_order_4_3_2() {
-    let (chain, _) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            NAME_ORDERING_CA_CERT,
-            INVALID_NAME_CHAINING_ORDER_TEST_2EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) =
-        common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, NAME_ORDER_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, _) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        NAME_ORDERING_CA_CERT,
+        INVALID_NAME_CHAINING_ORDER_TEST_2EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, NAME_ORDER_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     assert_eq!(
         chain.signing_key(&root, unix_time, crls.as_slice()),
@@ -101,19 +88,13 @@ fn invalid_name_chaining_order_4_3_2() {
 
 #[test]
 fn valid_name_chaining_whitespace_4_3_3() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_NAME_CHAINING_WHITESPACE_TEST_3EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_NAME_CHAINING_WHITESPACE_TEST_3EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -124,19 +105,13 @@ fn valid_name_chaining_whitespace_4_3_3() {
 
 #[test]
 fn valid_name_chaining_whitespace_4_3_4() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_NAME_CHAINING_WHITESPACE_TEST_4EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_NAME_CHAINING_WHITESPACE_TEST_4EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -147,19 +122,13 @@ fn valid_name_chaining_whitespace_4_3_4() {
 
 #[test]
 fn valid_name_chaining_capitalization_4_3_5() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            GOOD_CA_CERT,
-            VALID_NAME_CHAINING_CAPITALIZATION_TEST_5EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        GOOD_CA_CERT,
+        VALID_NAME_CHAINING_CAPITALIZATION_TEST_5EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, GOOD_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -170,19 +139,13 @@ fn valid_name_chaining_capitalization_4_3_5() {
 
 #[test]
 fn valid_name_chaining_uids_4_3_6() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            UID_CA_CERT,
-            VALID_NAME_UIDS_TEST_6EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, UID_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        UID_CA_CERT,
+        VALID_NAME_UIDS_TEST_6EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, UID_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -193,25 +156,16 @@ fn valid_name_chaining_uids_4_3_6() {
 
 #[test]
 fn valid_rfc3280_mandatory_attribute_types_4_3_7() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            RFC3280_MANDATORY_ATTRIBUTE_TYPES_CA_CERT,
-            VALID_RFC3280_MANDATORY_ATTRIBUTE_TYPES_TEST_7EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time(
-        [
-            TRUST_ANCHOR_ROOT_CRL,
-            RFC3280_MANDATORY_ATTRIBUTE_TYPES_CA_CRL,
-        ]
-        .as_slice(),
-    );
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        RFC3280_MANDATORY_ATTRIBUTE_TYPES_CA_CERT,
+        VALID_RFC3280_MANDATORY_ATTRIBUTE_TYPES_TEST_7EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[
+        TRUST_ANCHOR_ROOT_CRL,
+        RFC3280_MANDATORY_ATTRIBUTE_TYPES_CA_CRL,
+    ]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -222,25 +176,16 @@ fn valid_rfc3280_mandatory_attribute_types_4_3_7() {
 
 #[test]
 fn valid_rfc3280_optional_attribute_types_4_3_8() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            RFC3280_OPTIONAL_ATTRIBUTE_TYPES_CA_CERT,
-            VALID_RFC3280_OPTIONAL_ATTRIBUTE_TYPES_TEST_8EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time(
-        [
-            TRUST_ANCHOR_ROOT_CRL,
-            RFC3280_OPTIONAL_ATTRIBUTE_TYPES_CA_CRL,
-        ]
-        .as_slice(),
-    );
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        RFC3280_OPTIONAL_ATTRIBUTE_TYPES_CA_CERT,
+        VALID_RFC3280_OPTIONAL_ATTRIBUTE_TYPES_TEST_8EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[
+        TRUST_ANCHOR_ROOT_CRL,
+        RFC3280_OPTIONAL_ATTRIBUTE_TYPES_CA_CRL,
+    ]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -251,20 +196,14 @@ fn valid_rfc3280_optional_attribute_types_4_3_8() {
 
 #[test]
 fn valid_utf8_string_encoded_names_4_3_9() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            UTF8_STRING_ENCODED_NAMES_CA_CERT,
-            VALID_UTF8_STRING_ENCODED_NAMES_TEST_9EE,
-        ]
-        .as_slice(),
-    );
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        UTF8_STRING_ENCODED_NAMES_CA_CERT,
+        VALID_UTF8_STRING_ENCODED_NAMES_TEST_9EE,
+    ]);
     let (crls, unix_time) =
-        common::crls_and_time([TRUST_ANCHOR_ROOT_CRL, UTF8_STRING_ENCODED_NAMES_CA_CRL].as_slice());
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+        common::crls_and_time(&[TRUST_ANCHOR_ROOT_CRL, UTF8_STRING_ENCODED_NAMES_CA_CRL]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -275,25 +214,16 @@ fn valid_utf8_string_encoded_names_4_3_9() {
 
 #[test]
 fn valid_rollover_from_printable_to_utf8_4_3_10() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_CA_CERT,
-            VALID_ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_TEST_10EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time(
-        [
-            TRUST_ANCHOR_ROOT_CRL,
-            ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_CA_CRL,
-        ]
-        .as_slice(),
-    );
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_CA_CERT,
+        VALID_ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_TEST_10EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[
+        TRUST_ANCHOR_ROOT_CRL,
+        ROLLOVER_FROM_PRINTABLE_STRING_TO_UTF8_STRING_CA_CRL,
+    ]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())
@@ -304,25 +234,16 @@ fn valid_rollover_from_printable_to_utf8_4_3_10() {
 
 #[test]
 fn valid_utf8_string_case_insensitive_match_4_3_11() {
-    let (chain, expected_key) = common::chain_and_leaf_key(
-        [
-            TRUST_ANCHOR_ROOT_CERTIFICATE,
-            UTF8_STRING_CASE_INSENSITIVE_MATCH_CA_CERT,
-            VALID_UTF8_STRING_CASE_INSENSITIVE_MATCH_TEST_11EE,
-        ]
-        .as_slice(),
-    );
-    let (crls, unix_time) = common::crls_and_time(
-        [
-            TRUST_ANCHOR_ROOT_CRL,
-            UTF8_STRING_CASE_INSENSITIVE_MATCH_CA_CRL,
-        ]
-        .as_slice(),
-    );
-
-    let root = chain.as_ref()[0]
-        .verify_self_signed(unix_time)
-        .expect("Failed verifying root");
+    let (chain, expected_key) = common::chain_and_leaf_key(&[
+        TRUST_ANCHOR_ROOT_CERTIFICATE,
+        UTF8_STRING_CASE_INSENSITIVE_MATCH_CA_CERT,
+        VALID_UTF8_STRING_CASE_INSENSITIVE_MATCH_TEST_11EE,
+    ]);
+    let (crls, unix_time) = common::crls_and_time(&[
+        TRUST_ANCHOR_ROOT_CRL,
+        UTF8_STRING_CASE_INSENSITIVE_MATCH_CA_CRL,
+    ]);
+    let root = common::verified_root(&chain, unix_time);
 
     let signing_key = chain
         .signing_key(&root, unix_time, crls.as_slice())


### PR DESCRIPTION
Use const generics in the PKITS test support functions to minimize the
written footprint.

Added a support function to get the verified version of the self signed
root certificate in PKITS tests.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
