### PR TITLE
Add TCB struct and parser

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -14,7 +14,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-alloc = ["pem-rfc7468/alloc", "dep:const-oid", "dep:p256", "dep:x509-cert"]
+alloc = ["pem-rfc7468/alloc", "dep:const-oid", "dep:p256", "dep:x509-cert", "dep:serde_json", "dep:serde"]
 
 [dependencies]
 const-oid = { version = "0.9.2", default-features = false, optional = true }
@@ -22,6 +22,8 @@ displaydoc = { version = "0.2.1", default-features = false }
 mc-sgx-core-types = "0.6.0"
 p256 = { version = "0.13.0", default-features = false, features = ["ecdsa"], optional = true }
 pem-rfc7468 = { version = "0.7.0", default-features = false, optional = true }
+serde = { version = "1.0.162", default-features = false, features = ["derive"], optional = true }
+serde_json = { version = "1.0.66", default-features = false, features = ["alloc", "raw_value"], optional = true }
 subtle = { version = "2.4.0", default-features = false }
 x509-cert = { version = "0.2.0", default-features = false, optional = true }
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -7,6 +7,8 @@
 mod report_body;
 mod struct_name;
 #[cfg(feature = "alloc")]
+mod tcb;
+#[cfg(feature = "alloc")]
 mod x509;
 
 pub use report_body::{

--- a/verifier/src/tcb.rs
+++ b/verifier/src/tcb.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 The MobileCoin Foundation
+
+//! Verifier for TCB information
+//!
+//! See <https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-model-v3>
+//! for the format
+//!
+//! The TCB info is retrieved by using the fsmpc available in the report body
+//! and accessing <https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v4>
+
+#![allow(dead_code)]
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+
+/// Error parsing TCB info
+#[derive(Debug)]
+pub enum Error {
+    Serde(serde_json::Error),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error::Serde(e)
+    }
+}
+
+/// Raw unverified representation of the TCB info provided from
+/// <https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc={}>
+///
+/// Due to the way the TCB info is signed the contents should be provided as is.
+#[derive(Debug, Deserialize)]
+pub struct TcbInfoRaw<'a> {
+    tcb_info: &'a RawValue,
+    signature: &'a str,
+}
+
+impl<'a> TryFrom<&'a str> for TcbInfoRaw<'a> {
+    type Error = Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        let tcb_info: TcbInfoRaw = serde_json::from_str(value)?;
+        Ok(tcb_info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_unverified_tcb_info() {
+        // For this test we don't care what the contents of `tcb_info` is, just
+        // that we separate the signature from the tcb_info correctly.
+        let raw_info =
+            r#"{"tcb_info":{"id":"SGX","version":3,"fmspc":"00906ED50000"},"signature":"hello"}"#;
+        let tcb_info = TcbInfoRaw::try_from(raw_info).expect("Failed to parse TCB info");
+        assert_eq!(tcb_info.signature, "hello");
+        assert_eq!(
+            tcb_info.tcb_info.get(),
+            r#"{"id":"SGX","version":3,"fmspc":"00906ED50000"}"#
+        );
+    }
+
+    #[test]
+    fn two_signatures_errors() {
+        let raw_info = r#"{"tcb_info":{"id":"SGX","version":3,"fmspc":"00906ED50000"},"signature":"hello","signature":"fail"}"#;
+        assert!(matches!(
+            TcbInfoRaw::try_from(raw_info),
+            Err(Error::Serde(_))
+        ));
+    }
+
+    #[test]
+    fn two_tcb_infos_errors() {
+        let raw_info = r#"{"tcb_info":"too many cooks","tcb_info":{"id":"SGX","version":3,"fmspc":"00906ED50000"},"signature":"hello"}"#;
+        assert!(matches!(
+            TcbInfoRaw::try_from(raw_info),
+            Err(Error::Serde(_))
+        ));
+    }
+
+    #[test]
+    fn nested_tcb_info_still_in_parent() {
+        let raw_info = r#"{"tcb_info":{"tcb_info":"nested","version":3,"fmspc":"00906ED50000"},"signature":"hello"}"#;
+        let tcb_info = TcbInfoRaw::try_from(raw_info).expect("Failed to parse TCB info");
+        assert_eq!(tcb_info.signature, "hello");
+        assert_eq!(
+            tcb_info.tcb_info.get(),
+            r#"{"tcb_info":"nested","version":3,"fmspc":"00906ED50000"}"#
+        );
+    }
+}


### PR DESCRIPTION
Add the higher level TCB parser which separates the `tcb_info` from the
`signature` in the provided TCB data from
<https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc={}>

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
