### PR TITLE
Add method to get the leaf certificate from cert chain

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = { workspace = true }
 [features]
 tcb = ["dep:p256", "dep:serde_json", "dep:serde", "dep:der", "dep:hex", "advisories"]
 advisories = ["dep:serde_json"]
-x509 = ["dep:mbedtls"]
+x509 = ["dep:mbedtls", "dep:x509-cert"]
 
 [dependencies]
 der = { version = "0.7.5", default-features = false, optional = true }
@@ -28,6 +28,7 @@ p256 = { version = "0.13.0", default-features = false, features = ["ecdsa"], opt
 serde = { version = "1.0.162", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0.66", default-features = false, features = ["alloc", "raw_value"], optional = true }
 subtle = { version = "2.4.0", default-features = false }
+x509-cert = { version = "0.2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 mc-sgx-core-sys-types = "0.6.0"


### PR DESCRIPTION
The `VerifiedCertChain` now provides a method `leaf()` to get the leaf
certificate of the chain. If the certificate chain is composed of only
CA certificates then `None` will be returned.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
