### PR TITLE
Exclude RUSTSEC-2020-0071 in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # This comes via mbedtls, but only when
+    # `[target.x86_64-fortanix-unknown-sgx.dependencies]`
+    # which we don't use
+    "RUSTSEC-2020-0071",
+]


### PR DESCRIPTION
Currently `time`, which causes RUSTSEC-2020-0071 only comes in via
mbedtls when it uses the
`[target.x86_64-fortanix-unknown-sgx.dependencies]` target triple.
This repo doesn't use that target triple so is unaffected by the
advisory.

This is meant to fix the following CI failures, https://github.com/mobilecoinfoundation/attestation/actions/runs/5116212565
