### PR TITLE
Ensure QE identity version matches

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -33,6 +33,7 @@ x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
 [dev-dependencies]
 assert_matches = "1.5.0"
 mc-sgx-dcap-sys-types = "0.7.0"
+rand = "0.8.5"
 textwrap = "0.16.0"
 yare = "1.0.2"
 

--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -33,8 +33,9 @@ pub enum Error {
     QeIdentityExpired,
     /// QE identity not yet valid
     QeIdentityNotYetValid,
-    /// QE identity version mismatch, expecting 2 got {0}
-    QeIdentityVersion(u32),
+    /// QE identity version mismatch, expecting {expected} got {actual}
+    #[allow(missing_docs)]
+    QeIdentityVersion { expected: u32, actual: u32 },
 }
 
 impl From<der::Error> for Error {

--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     QeIdentityExpired,
     /// QE identity not yet valid
     QeIdentityNotYetValid,
+    /// QE identity version mismatch, expecting 2 got {0}
+    QeIdentityVersion(u32),
 }
 
 impl From<der::Error> for Error {


### PR DESCRIPTION
Adding a version check to ensure no new fields get added to the JSON
output that should be considered for verification.

The verification of the QE identity is a bit sparse. It is documented as Version 2, but there is nothing saying what version 1 was.
While it's likely a new version would be a structurally breaking change, in the chance that it's not a breaking change, this adds verification that the received JSON is specified as version 2.   

One can see how version 2 of TCB info changed, https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v2
to version 3, https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v4.
It was a breaking change

