### PR TITLE
Rename `TcbInfoRaw` to `SignedTcbInfo`

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -33,7 +33,7 @@ pub use report_body::{
     MiscellaneousSelectVerifier, MrEnclaveVerifier, MrSignerVerifier, ReportDataVerifier,
 };
 
-pub use tcb::{TcbInfo, TcbInfoRaw, TcbInfoRawVerifier};
+pub use tcb::{SignedTcbInfo, SignedTcbInfoVerifier, TcbInfo};
 
 #[cfg(feature = "x509")]
 pub use x509::{


### PR DESCRIPTION
Rename `TcbInfoRaw` to `SignedTcbInfo` for consistency with
`SignedQeIdentity`.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
