### PR TITLE
Add `SignedQeIdentity` to `Evidence`

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -23,7 +23,7 @@ pub use error::Error;
 pub(crate) use error::Result;
 pub use evidence::Evidence;
 
-pub use qe_identity::QeIdentity;
+pub use qe_identity::{QeIdentity, SignedQeIdentity, SignedQeIdentityVerifier};
 pub use qe_report_body::{QeReportBody, QeReportBodyVerifier};
 pub use quote::Quote3Verifier;
 


### PR DESCRIPTION
The `Evidence` type will now try to decode the `SignedQeIdentity` and
`QeIdentity` from the provided `Collateral`.

