### PR TITLE
Add `TrustedIdentitiesVerifier`

### DIFF
--- a/verifier/src/identity.rs
+++ b/verifier/src/identity.rs
@@ -7,10 +7,14 @@
 //! [Intel SGX ECDSA QuoteLibReference DCAP API](https://download.01.org/intel-sgx/sgx-dcap/1.16/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf#%5B%7B%22num%22%3A63%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C468%2C0%5D)
 //! documents the identity types, Strict Policy and Security Policy.
 
-use crate::{Advisories, AdvisoryStatus};
+use crate::{
+    Accessor, Advisories, AdvisoriesVerifier, AdvisoryStatus, And, MrEnclaveVerifier,
+    MrSignerVerifier, VerificationOutput, Verifier,
+};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::ops::Not;
+use mc_sgx_core_types::{IsvProductId, IsvSvn, MrEnclave, MrSigner};
 use serde::{Deserialize, Serialize};
 
 /// Trusted identity for MRENCLAVE values.
@@ -46,7 +50,7 @@ pub struct TrustedMrEnclaveIdentity {
 impl TrustedMrEnclaveIdentity {
     /// Create a new instance.
     pub fn new<'a, CA, I, HA, J>(
-        mr_enclave: &[u8; 32],
+        mr_enclave: &MrEnclave,
         config_advisories: I,
         hardening_advisories: J,
     ) -> Self
@@ -56,8 +60,10 @@ impl TrustedMrEnclaveIdentity {
         J: IntoIterator<Item = &'a HA>,
         HA: ToString + 'a + ?Sized,
     {
+        let mut local_mr_enclave = [0u8; 32];
+        local_mr_enclave.copy_from_slice(mr_enclave.as_ref());
         Self {
-            mr_enclave: *mr_enclave,
+            mr_enclave: local_mr_enclave,
             mitigated_config_advisories: config_advisories
                 .into_iter()
                 .map(ToString::to_string)
@@ -67,6 +73,11 @@ impl TrustedMrEnclaveIdentity {
                 .map(ToString::to_string)
                 .collect(),
         }
+    }
+
+    /// Get the MRENCLAVE measurement for this identity
+    pub fn mr_enclave(&self) -> MrEnclave {
+        self.mr_enclave.into()
     }
 
     /// Get the known allowed [`Advisories`] for this identity.
@@ -118,9 +129,9 @@ pub struct TrustedMrSignerIdentity {
 impl TrustedMrSignerIdentity {
     /// Create a new instance.
     pub fn new<'a, CA, I, HA, J>(
-        mr_signer: &[u8; 32],
-        product_id: u16,
-        minimum_svn: u16,
+        mr_signer: &MrSigner,
+        isv_product_id: IsvProductId,
+        isv_svn: IsvSvn,
         config_advisories: I,
         hardening_advisories: J,
     ) -> Self
@@ -130,10 +141,13 @@ impl TrustedMrSignerIdentity {
         J: IntoIterator<Item = &'a HA>,
         HA: ToString + 'a + ?Sized,
     {
+        let mut local_mr_signer = [0u8; 32];
+        local_mr_signer.copy_from_slice(mr_signer.as_ref());
+
         Self {
-            mr_signer: *mr_signer,
-            product_id,
-            minimum_svn,
+            mr_signer: local_mr_signer,
+            product_id: isv_product_id.into(),
+            minimum_svn: isv_svn.into(),
             mitigated_config_advisories: config_advisories
                 .into_iter()
                 .map(ToString::to_string)
@@ -143,6 +157,21 @@ impl TrustedMrSignerIdentity {
                 .map(ToString::to_string)
                 .collect(),
         }
+    }
+
+    /// Get the MRSIGNER hash value for this identity
+    pub fn mr_signer(&self) -> MrSigner {
+        self.mr_signer.into()
+    }
+
+    /// Get the ISV product ID for this identity
+    pub fn isv_product_id(&self) -> IsvProductId {
+        self.product_id.into()
+    }
+
+    /// Get the ISV SVN for this identity
+    pub fn isv_svn(&self) -> IsvSvn {
+        self.minimum_svn.into()
     }
 
     /// Get the known allowed [`Advisories`] for this identity.
@@ -166,6 +195,12 @@ pub enum TrustedIdentity {
     MrEnclave(TrustedMrEnclaveIdentity),
     /// MRSIGNER identity type
     MrSigner(TrustedMrSignerIdentity),
+}
+
+impl From<&TrustedIdentity> for TrustedIdentity {
+    fn from(identity: &TrustedIdentity) -> Self {
+        identity.clone()
+    }
 }
 
 impl From<TrustedMrEnclaveIdentity> for TrustedIdentity {
@@ -200,14 +235,175 @@ fn mitigated_advisories_to_advisories(
     Advisories::new(advisories, status)
 }
 
+/// A verifier for determining if one of the provided identities matches the enclave.
+#[derive(Clone, Debug)]
+pub struct TrustedIdentitiesVerifier {
+    identity_verifiers: Vec<TrustedIdentityVerifier>,
+}
+
+impl TrustedIdentitiesVerifier {
+    /// Create a new instance
+    ///
+    /// # Arguments
+    /// - `identities` - The iterator of identities to check against
+    pub fn new<I, ID>(identities: I) -> Self
+    where
+        I: IntoIterator<Item = ID>,
+        ID: Into<TrustedIdentity>,
+    {
+        let identity_verifiers = identities
+            .into_iter()
+            .map(|id| TrustedIdentityVerifier::from(id.into()))
+            .collect();
+
+        Self { identity_verifiers }
+    }
+}
+
+impl<E> Verifier<E> for TrustedIdentitiesVerifier
+where
+    E: Accessor<MrEnclave>
+        + Accessor<MrSigner>
+        + Accessor<Advisories>
+        + Accessor<IsvProductId>
+        + Accessor<IsvSvn>,
+{
+    type Value = ();
+    fn verify(&self, evidence: &E) -> VerificationOutput<Self::Value> {
+        let result = self
+            .identity_verifiers
+            .iter()
+            .find_map(|identity_verifier| {
+                let result = match identity_verifier {
+                    TrustedIdentityVerifier::MrEnclave(mr_enclave) => {
+                        mr_enclave.verifier.verify(evidence).is_success()
+                    }
+                    TrustedIdentityVerifier::MrSigner(mr_signer) => {
+                        mr_signer.verifier.verify(evidence).is_success()
+                    }
+                };
+
+                match result.unwrap_u8() {
+                    1 => Some(VerificationOutput::new((), result)),
+                    _ => None,
+                }
+            });
+
+        result.unwrap_or(VerificationOutput::new((), 0.into()))
+    }
+}
+
+/// A verifier for looking at a single identity
+///
+/// This can be a bit confusing with the `TrustedIdentitiesVerifier`. This type is to handle *one*
+/// identity, while the `TrustedIdentitiesVerifier` is for verifying one of *multiple* identities.
+#[derive(Debug, Clone)]
+enum TrustedIdentityVerifier {
+    MrEnclave(TrustedMrEnclaveIdentityVerifier),
+    MrSigner(TrustedMrSignerIdentityVerifier),
+}
+
+impl From<TrustedIdentity> for TrustedIdentityVerifier {
+    fn from(identity: TrustedIdentity) -> Self {
+        match identity {
+            TrustedIdentity::MrEnclave(mr_enclave) => Self::MrEnclave(mr_enclave.into()),
+            TrustedIdentity::MrSigner(mr_signer) => Self::MrSigner(mr_signer.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TrustedMrEnclaveIdentityVerifier {
+    verifier: And<MrEnclaveVerifier, AdvisoriesVerifier>,
+}
+
+impl From<TrustedMrEnclaveIdentity> for TrustedMrEnclaveIdentityVerifier {
+    fn from(identity: TrustedMrEnclaveIdentity) -> Self {
+        let verifier = And::new(
+            MrEnclaveVerifier::new(identity.mr_enclave()),
+            AdvisoriesVerifier::new(identity.advisories()),
+        );
+        Self { verifier }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TrustedMrSignerIdentityVerifier {
+    verifier: And<MrSignerVerifier, AdvisoriesVerifier>,
+}
+
+impl From<TrustedMrSignerIdentity> for TrustedMrSignerIdentityVerifier {
+    fn from(identity: TrustedMrSignerIdentity) -> Self {
+        let verifier = And::new(
+            MrSignerVerifier::new(
+                identity.mr_signer(),
+                identity.isv_product_id(),
+                identity.isv_svn(),
+            ),
+            AdvisoriesVerifier::new(identity.advisories()),
+        );
+        Self { verifier }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
+    /// An identity to use in testing the different identity verifiers.
+    struct Identity {
+        mr_enclave: MrEnclave,
+        mr_signer: MrSigner,
+        isv_product_id: IsvProductId,
+        isv_svn: IsvSvn,
+        advisories: Advisories,
+    }
+
+    /// Macro to generate boilerplate for implementing [`Accessor`] for a field of
+    /// the testing identity
+    ///
+    /// # Arguments
+    /// * `field_type` - The type of the field in
+    /// * `field_name` - The name of the field on
+    macro_rules! identity_accessor {
+        ($($field_type:ty, $field_name:ident;)*) => {$(
+            impl Accessor<$field_type> for Identity {
+                fn get(&self) -> $field_type {
+                    self.$field_name.clone()
+                }
+            }
+        )*}
+    }
+
+    identity_accessor! {
+        MrEnclave, mr_enclave;
+        MrSigner, mr_signer;
+        IsvProductId, isv_product_id;
+        IsvSvn, isv_svn;
+        Advisories, advisories;
+    }
+
+    /// An identity for use in tests.
+    ///
+    /// All of the values are fixed because the individual verifiers are robustly tested and these
+    /// tests are to ensure the identity verifiers are composed correctly.
+    fn identity() -> Identity {
+        Identity {
+            mr_enclave: [1; 32].into(),
+            mr_signer: [2; 32].into(),
+            isv_product_id: 3.into(),
+            isv_svn: 4.into(),
+            advisories: Advisories::new(
+                ["one", "two", "three", "four"],
+                AdvisoryStatus::ConfigurationAndSWHardeningNeeded,
+            ),
+        }
+    }
+
     #[test]
     fn up_to_date_advisories_for_mr_enclave_identity() {
         let mr_enclave_identity =
-            TrustedMrEnclaveIdentity::new(&[5; 32], [] as [&str; 0], [] as [&str; 0]);
+            TrustedMrEnclaveIdentity::new(&[5; 32].into(), [] as [&str; 0], [] as [&str; 0]);
         assert_eq!(
             mr_enclave_identity.advisories(),
             Advisories::new([] as [&str; 0], AdvisoryStatus::UpToDate)
@@ -217,7 +413,7 @@ mod test {
     #[test]
     fn config_needed_advisories_for_mr_enclave_identity() {
         let mr_enclave_identity = TrustedMrEnclaveIdentity::new(
-            &[5; 32],
+            &[5; 32].into(),
             ["an advisory", "another one"],
             [] as [&str; 0],
         );
@@ -232,8 +428,11 @@ mod test {
 
     #[test]
     fn sw_hardening_needed_advisories_for_mr_enclave_identity() {
-        let mr_enclave_identity =
-            TrustedMrEnclaveIdentity::new(&[5; 32], [] as [&str; 0], ["what's", "up", "doc"]);
+        let mr_enclave_identity = TrustedMrEnclaveIdentity::new(
+            &[5; 32].into(),
+            [] as [&str; 0],
+            ["what's", "up", "doc"],
+        );
         assert_eq!(
             mr_enclave_identity.advisories(),
             Advisories::new(["what's", "up", "doc"], AdvisoryStatus::SWHardeningNeeded)
@@ -243,7 +442,7 @@ mod test {
     #[test]
     fn config_and_sw_hardening_needed_advisories_for_mr_enclave_identity() {
         let mr_enclave_identity =
-            TrustedMrEnclaveIdentity::new(&[5; 32], ["one", "two"], ["three", "four"]);
+            TrustedMrEnclaveIdentity::new(&[5; 32].into(), ["one", "two"], ["three", "four"]);
         assert_eq!(
             mr_enclave_identity.advisories(),
             Advisories::new(
@@ -255,8 +454,13 @@ mod test {
 
     #[test]
     fn up_to_date_advisories_for_mr_signer_identity() {
-        let mr_signer_identity =
-            TrustedMrSignerIdentity::new(&[8; 32], 9, 10, [] as [&str; 0], [] as [&str; 0]);
+        let mr_signer_identity = TrustedMrSignerIdentity::new(
+            &[8; 32].into(),
+            9.into(),
+            10.into(),
+            [] as [&str; 0],
+            [] as [&str; 0],
+        );
         assert_eq!(
             mr_signer_identity.advisories(),
             Advisories::new([] as [&str; 0], AdvisoryStatus::UpToDate)
@@ -265,8 +469,13 @@ mod test {
 
     #[test]
     fn config_needed_advisories_for_mr_signer_identity() {
-        let mr_signer_identity =
-            TrustedMrSignerIdentity::new(&[8; 32], 9, 10, ["mr", "signer"], [] as [&str; 0]);
+        let mr_signer_identity = TrustedMrSignerIdentity::new(
+            &[8; 32].into(),
+            9.into(),
+            10.into(),
+            ["mr", "signer"],
+            [] as [&str; 0],
+        );
         assert_eq!(
             mr_signer_identity.advisories(),
             Advisories::new(["mr", "signer"], AdvisoryStatus::ConfigurationNeeded)
@@ -275,8 +484,13 @@ mod test {
 
     #[test]
     fn sw_hardening_needed_advisories_for_mr_signer_identity() {
-        let mr_signer_identity =
-            TrustedMrSignerIdentity::new(&[5; 32], 9, 10, [] as [&str; 0], ["who's", "there?"]);
+        let mr_signer_identity = TrustedMrSignerIdentity::new(
+            &[5; 32].into(),
+            9.into(),
+            10.into(),
+            [] as [&str; 0],
+            ["who's", "there?"],
+        );
         assert_eq!(
             mr_signer_identity.advisories(),
             Advisories::new(["who's", "there?"], AdvisoryStatus::SWHardeningNeeded)
@@ -285,8 +499,13 @@ mod test {
 
     #[test]
     fn config_and_sw_hardening_needed_advisories_for_mr_signer_identity() {
-        let mr_signer_identity =
-            TrustedMrSignerIdentity::new(&[5; 32], 9, 10, ["nine", "8"], ["seven", "6"]);
+        let mr_signer_identity = TrustedMrSignerIdentity::new(
+            &[5; 32].into(),
+            9.into(),
+            10.into(),
+            ["nine", "8"],
+            ["seven", "6"],
+        );
         assert_eq!(
             mr_signer_identity.advisories(),
             Advisories::new(
@@ -294,5 +513,101 @@ mod test {
                 AdvisoryStatus::ConfigurationAndSWHardeningNeeded
             )
         );
+    }
+
+    #[test]
+    fn identity_verifiers_one_identity_matches() {
+        let identity = identity();
+        let allowed_identities: &[TrustedIdentity] = &[TrustedMrEnclaveIdentity::new(
+            &identity.mr_enclave,
+            ["one", "two"],
+            ["three", "four"],
+        )
+        .into()];
+        let verifier = TrustedIdentitiesVerifier::new(allowed_identities);
+        let verification = verifier.verify(&identity);
+        assert_eq!(verification.is_success().unwrap_u8(), 1);
+    }
+
+    #[test]
+    fn identity_verifiers_middle_identity_matches() {
+        let identity = identity();
+
+        let allowed_identities: &[TrustedIdentity] = &[
+            TrustedMrEnclaveIdentity::new(&[11; 32].into(), ["one", "two"], ["three", "four"])
+                .into(),
+            TrustedMrSignerIdentity::new(
+                &identity.mr_signer,
+                identity.isv_product_id,
+                identity.isv_svn,
+                ["one", "two"],
+                ["three", "four"],
+            )
+            .into(),
+            TrustedMrEnclaveIdentity::new(&identity.mr_enclave, ["two"], ["three", "four"]).into(),
+        ];
+        let verifier = TrustedIdentitiesVerifier::new(allowed_identities);
+        let verification = verifier.verify(&identity);
+        assert_eq!(verification.is_success().unwrap_u8(), 1);
+    }
+
+    #[test]
+    fn identities_verifier_no_matches() {
+        let identity = identity();
+
+        let allowed_identities: &[TrustedIdentity] = &[
+            // Mismatched MRENCLAVE
+            TrustedMrEnclaveIdentity::new(&[11; 32].into(), ["one", "two"], ["three", "four"])
+                .into(),
+            // Mismatched MRSIGNER
+            TrustedMrSignerIdentity::new(
+                &[12; 32].into(),
+                identity.isv_product_id,
+                identity.isv_svn,
+                ["one", "two"],
+                ["three", "four"],
+            )
+            .into(),
+            // Mismatched product ID
+            TrustedMrSignerIdentity::new(
+                &identity.mr_signer,
+                (identity.isv_product_id.as_ref() - 1).into(),
+                identity.isv_svn,
+                ["one", "two"],
+                ["three", "four"],
+            )
+            .into(),
+            // Required SVN is greater than the identity's SVN
+            TrustedMrSignerIdentity::new(
+                &identity.mr_signer,
+                identity.isv_product_id,
+                (identity.isv_svn.as_ref() + 1).into(),
+                ["one", "two"],
+                ["three", "four"],
+            )
+            .into(),
+            // Requires an advisory status no worse than AdvisoryStatus::ConfigurationNeeded
+            TrustedMrSignerIdentity::new(
+                &identity.mr_signer,
+                identity.isv_product_id,
+                identity.isv_svn,
+                ["one", "two", "three", "four"],
+                [] as [&str; 0],
+            )
+            .into(),
+            // Requires an advisory status no worse than AdvisoryStatus::SWHardeningNeeded
+            TrustedMrEnclaveIdentity::new(
+                &identity.mr_enclave,
+                [] as [&str; 0],
+                ["one", "two", "three", "four"],
+            )
+            .into(),
+            // Doesn't allow the "four" advisory id
+            TrustedMrEnclaveIdentity::new(&identity.mr_enclave, ["one", "two"], ["three"]).into(),
+        ];
+
+        let verifier = TrustedIdentitiesVerifier::new(allowed_identities);
+        let verification = verifier.verify(&identity);
+        assert_eq!(verification.is_success().unwrap_u8(), 0);
     }
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -24,7 +24,9 @@ pub use error::Error;
 pub(crate) use error::Result;
 pub use evidence::Evidence;
 
-pub use identity::{TrustedIdentity, TrustedMrEnclaveIdentity, TrustedMrSignerIdentity};
+pub use identity::{
+    TrustedIdentitiesVerifier, TrustedIdentity, TrustedMrEnclaveIdentity, TrustedMrSignerIdentity,
+};
 
 pub use qe_identity::{QeIdentity, SignedQeIdentity, SignedQeIdentityVerifier};
 pub use qe_report_body::{QeReportBody, QeReportBodyVerifier};
@@ -349,7 +351,7 @@ impl<L, R> AndOutput<L, R> {
 ///
 /// This is will be a long operation. If the `left` side fails
 /// the `right` side will *still* be exercised.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct And<L, R> {
     left: L,
     right: R,


### PR DESCRIPTION
The `TrustedIdentitiesVerifier` will verify that one of the provided
identities matches the enclave's identity.

