### PR TITLE
Add `CertificateChainVerifier` implementation

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -14,7 +14,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-x509 = ["dep:mbedtls"]
+mbedtls = ["dep:mbedtls"]
 
 [dependencies]
 der = { version = "0.7.7", default-features = false }

--- a/verifier/src/advisories.rs
+++ b/verifier/src/advisories.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2023 The MobileCoin Foundation
 
 use crate::{Accessor, SpacedStructName, VerificationOutput, Verifier};
-use alloc::collections::BTreeSet;
-use alloc::string::{String, ToString};
+use alloc::{
+    collections::BTreeSet,
+    string::{String, ToString},
+};
 use core::fmt::{Display, Formatter};
 use serde::Deserialize;
 

--- a/verifier/src/certificate_chain.rs
+++ b/verifier/src/certificate_chain.rs
@@ -7,7 +7,7 @@ use x509_cert::crl::CertificateList;
 use x509_cert::Certificate;
 
 /// Error verifying a certificate chain
-#[derive(displaydoc::Display, Debug, Clone)]
+#[derive(displaydoc::Display, Debug, Clone, PartialEq)]
 pub enum CertificateChainVerifierError {
     /// X509 certificate not yet valid
     CertificateNotYetValid,

--- a/verifier/src/certificate_chain.rs
+++ b/verifier/src/certificate_chain.rs
@@ -3,8 +3,7 @@
 //! Trait and Error for verifying certificate chains
 
 use der::DateTime;
-use x509_cert::crl::CertificateList;
-use x509_cert::Certificate;
+use x509_cert::{crl::CertificateList, Certificate};
 
 /// Error verifying a certificate chain
 #[derive(displaydoc::Display, Debug, Clone, PartialEq)]

--- a/verifier/src/evidence.rs
+++ b/verifier/src/evidence.rs
@@ -445,6 +445,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(feature = "x509")]
+    use crate::{TrustAnchor, X509CertificateChainVerifier};
     use crate::{TrustedMrEnclaveIdentity, VerificationTreeDisplay, Verifier};
     use alloc::format;
     use alloc::string::{String, ToString};
@@ -968,6 +970,47 @@ mod test {
                 - [x] The expected attributes is Flags: INITTED | PROVISION_KEY Xfrm: (none) with mask Flags: 0xFFFF_FFFF_FFFF_FFFB Xfrm: (none)
                 - [x] The ISV SVN should correspond to an `UpToDate` level with no advisories, from: [TcbLevel { tcb: Tcb { isv_svn: 8 }, tcb_date: "2023-02-15T00:00:00Z", tcb_status: UpToDate, advisory_ids: [] }, TcbLevel { tcb: Tcb { isv_svn: 6 }, tcb_date: "2021-11-10T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 5 }, tcb_date: "2020-11-11T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 4 }, tcb_date: "2019-11-13T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 2 }, tcb_date: "2019-05-15T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00219", "INTEL-SA-00293", "INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 1 }, tcb_date: "2018-08-15T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00202", "INTEL-SA-00219", "INTEL-SA-00293", "INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }]
               - [ ] The quote signature did not match provided key
+              - [x] Both of the following must be true:
+                - [x] The MRENCLAVE should be 840d61b0585dc8b4dc90f53af293c760fda06bee75978a6a86263ffb296423f4
+                - [x] The allowed advisories are IDs: {"INTEL-SA-00334", "INTEL-SA-00615"} Status: SWHardeningNeeded"#;
+        assert_eq!(format!("\n{displayable}"), textwrap::dedent(expected));
+    }
+
+    #[cfg(feature = "x509")]
+    #[test]
+    fn evidence_verifier_succeeds_with_mbedtls_x509_verifier() {
+        let time = valid_test_time();
+        let root_ca = include_str!("../data/tests/root_ca.pem");
+        let trust_anchor = TrustAnchor::try_from_pem(root_ca).expect("Failed to parse root CA");
+        let certificate_verifier = X509CertificateChainVerifier::new(trust_anchor);
+        let identities = [valid_test_trusted_identity()];
+        let verifier = EvidenceVerifier::new(&certificate_verifier, identities, time);
+        let quote_bytes = include_bytes!("../data/tests/hw_quote.dat");
+        let quote = Quote3::try_from(quote_bytes.as_ref()).expect("Failed to parse quote");
+        let collateral = collateral(TCB_INFO_JSON, QE_IDENTITY_JSON);
+        let evidence: Evidence<Vec<u8>> = Evidence::new(quote, collateral)
+            .expect("Failed to create evidence")
+            .into();
+
+        let verification = verifier.verify(&evidence);
+
+        assert_eq!(verification.is_success().unwrap_u8(), 1);
+
+        let displayable = VerificationTreeDisplay::new(&verifier, verification);
+        let expected = r#"
+            - [x] all of the following must be true:
+              - [x] The TCB issuer chain was verified.
+              - [x] The QE identity issuer chain was verified.
+              - [x] The Quote issuer chain was verified.
+              - [x] The TCB info was verified for the provided key
+              - [x] The QE identity was verified for the provided key
+              - [x] QE Report Body all of the following must be true:
+                - [x] The MRSIGNER key hash should be 8c4f5775d796503e96137f77c68a829a0056ac8ded70140b081b094490c57bff
+                - [x] The ISV product ID should be 1
+                - [x] The expected miscellaneous select is 0x0000_0000 with mask 0xFFFF_FFFF
+                - [x] The expected attributes is Flags: INITTED | PROVISION_KEY Xfrm: (none) with mask Flags: 0xFFFF_FFFF_FFFF_FFFB Xfrm: (none)
+                - [x] The ISV SVN should correspond to an `UpToDate` level with no advisories, from: [TcbLevel { tcb: Tcb { isv_svn: 8 }, tcb_date: "2023-02-15T00:00:00Z", tcb_status: UpToDate, advisory_ids: [] }, TcbLevel { tcb: Tcb { isv_svn: 6 }, tcb_date: "2021-11-10T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 5 }, tcb_date: "2020-11-11T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 4 }, tcb_date: "2019-11-13T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 2 }, tcb_date: "2019-05-15T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00219", "INTEL-SA-00293", "INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }, TcbLevel { tcb: Tcb { isv_svn: 1 }, tcb_date: "2018-08-15T00:00:00Z", tcb_status: OutOfDate, advisory_ids: ["INTEL-SA-00202", "INTEL-SA-00219", "INTEL-SA-00293", "INTEL-SA-00334", "INTEL-SA-00477", "INTEL-SA-00615"] }]
+              - [x] The quote was signed with the provided key
               - [x] Both of the following must be true:
                 - [x] The MRENCLAVE should be 840d61b0585dc8b4dc90f53af293c760fda06bee75978a6a86263ffb296423f4
                 - [x] The allowed advisories are IDs: {"INTEL-SA-00334", "INTEL-SA-00615"} Status: SWHardeningNeeded"#;

--- a/verifier/src/evidence.rs
+++ b/verifier/src/evidence.rs
@@ -2,14 +2,13 @@
 
 //! The full set of evidence needed for attesting a quote
 
-use crate::identity::TrustedIdentityValue;
-use crate::qe_report_body::QeReportBodyValue;
 use crate::{
-    choice_to_status_message, Accessor, Advisories, CertificateChainVerifier,
-    CertificateChainVerifierError, Error, QeIdentity, QeReportBody, QeReportBodyVerifier,
-    Quote3Verifier, SignedQeIdentity, SignedQeIdentityVerifier, SignedTcbInfo,
-    SignedTcbInfoVerifier, TcbInfo, TrustedIdentitiesVerifier, TrustedIdentity,
-    VerificationMessage, VerificationOutput, Verifier, MESSAGE_INDENT,
+    choice_to_status_message, identity::TrustedIdentityValue, qe_report_body::QeReportBodyValue,
+    Accessor, Advisories, CertificateChainVerifier, CertificateChainVerifierError, Error,
+    QeIdentity, QeReportBody, QeReportBodyVerifier, Quote3Verifier, SignedQeIdentity,
+    SignedQeIdentityVerifier, SignedTcbInfo, SignedTcbInfoVerifier, TcbInfo,
+    TrustedIdentitiesVerifier, TrustedIdentity, VerificationMessage, VerificationOutput, Verifier,
+    MESSAGE_INDENT,
 };
 use alloc::vec::Vec;
 use core::fmt::Formatter;
@@ -20,8 +19,7 @@ use mc_sgx_core_types::{
 };
 use mc_sgx_dcap_types::{CertificationData, Collateral, Quote3, TcbInfo as QuoteTcbInfo};
 use p256::ecdsa::VerifyingKey;
-use x509_cert::crl::CertificateList;
-use x509_cert::Certificate;
+use x509_cert::{crl::CertificateList, Certificate};
 
 /// The full set of evidence needed for verifying a quote
 ///
@@ -445,11 +443,13 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    #[cfg(feature = "x509")]
-    use crate::{TrustAnchor, X509CertificateChainVerifier};
+    #[cfg(feature = "mbedtls")]
+    use crate::{MbedTlsCertificateChainVerifier, TrustAnchor};
     use crate::{TrustedMrEnclaveIdentity, VerificationTreeDisplay, Verifier};
-    use alloc::format;
-    use alloc::string::{String, ToString};
+    use alloc::{
+        format,
+        string::{String, ToString},
+    };
     use assert_matches::assert_matches;
     use core::mem;
     use mc_sgx_dcap_sys_types::{sgx_ql_ecdsa_sig_data_t, sgx_ql_qve_collateral_t, sgx_quote3_t};
@@ -976,13 +976,13 @@ mod test {
         assert_eq!(format!("\n{displayable}"), textwrap::dedent(expected));
     }
 
-    #[cfg(feature = "x509")]
+    #[cfg(feature = "mbedtls")]
     #[test]
     fn evidence_verifier_succeeds_with_mbedtls_x509_verifier() {
         let time = valid_test_time();
         let root_ca = include_str!("../data/tests/root_ca.pem");
         let trust_anchor = TrustAnchor::try_from_pem(root_ca).expect("Failed to parse root CA");
-        let certificate_verifier = X509CertificateChainVerifier::new(trust_anchor);
+        let certificate_verifier = MbedTlsCertificateChainVerifier::new(trust_anchor);
         let identities = [valid_test_trusted_identity()];
         let verifier = EvidenceVerifier::new(&certificate_verifier, identities, time);
         let quote_bytes = include_bytes!("../data/tests/hw_quote.dat");

--- a/verifier/src/identity.rs
+++ b/verifier/src/identity.rs
@@ -7,16 +7,16 @@
 //! [Intel SGX ECDSA QuoteLibReference DCAP API](https://download.01.org/intel-sgx/sgx-dcap/1.16/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf#%5B%7B%22num%22%3A63%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C468%2C0%5D)
 //! documents the identity types, Strict Policy and Security Policy.
 
-use crate::report_body::MrSignerValue;
-use crate::struct_name::SpacedStructName;
 use crate::{
-    Accessor, Advisories, AdvisoriesVerifier, AdvisoryStatus, And, AndOutput, MrEnclaveVerifier,
-    MrSignerVerifier, VerificationMessage, VerificationOutput, Verifier, MESSAGE_INDENT,
+    report_body::MrSignerValue, struct_name::SpacedStructName, Accessor, Advisories,
+    AdvisoriesVerifier, AdvisoryStatus, And, AndOutput, MrEnclaveVerifier, MrSignerVerifier,
+    VerificationMessage, VerificationOutput, Verifier, MESSAGE_INDENT,
 };
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
-use core::fmt::Formatter;
-use core::ops::Not;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{fmt::Formatter, ops::Not};
 use mc_sgx_core_types::{IsvProductId, IsvSvn, MrEnclave, MrSigner};
 use serde::{Deserialize, Serialize};
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -11,14 +11,14 @@ mod certificate_chain;
 mod error;
 mod evidence;
 mod identity;
+#[cfg(feature = "mbedtls")]
+mod mbedtls;
 mod qe_identity;
 mod qe_report_body;
 mod quote;
 mod report_body;
 mod struct_name;
 mod tcb;
-#[cfg(feature = "x509")]
-mod x509;
 
 pub use advisories::{Advisories, AdvisoriesVerifier, AdvisoryStatus};
 pub use certificate_chain::{CertificateChainVerifier, CertificateChainVerifierError};
@@ -41,12 +41,14 @@ pub use report_body::{
 
 pub use tcb::{SignedTcbInfo, SignedTcbInfoVerifier, TcbInfo};
 
-#[cfg(feature = "x509")]
-pub use x509::{Error as X509Error, TrustAnchor, X509CertificateChainVerifier};
+#[cfg(feature = "mbedtls")]
+pub use crate::mbedtls::{Error as MbedTlsError, MbedTlsCertificateChainVerifier, TrustAnchor};
 
 use crate::struct_name::SpacedStructName;
-use core::fmt::{Debug, Display, Formatter};
-use core::ops::BitAnd;
+use core::{
+    fmt::{Debug, Display, Formatter},
+    ops::BitAnd,
+};
 use subtle::Choice;
 
 /// Number of spaces to indent nested messages.

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -42,10 +42,7 @@ pub use report_body::{
 pub use tcb::{SignedTcbInfo, SignedTcbInfoVerifier, TcbInfo};
 
 #[cfg(feature = "x509")]
-pub use x509::{
-    CertificateRevocationList, Error as X509Error, TrustAnchor, UnverifiedCertChain,
-    VerifiedCertChain,
-};
+pub use x509::{Error as X509Error, TrustAnchor, X509CertificateChainVerifier};
 
 use crate::struct_name::SpacedStructName;
 use core::fmt::{Debug, Display, Formatter};

--- a/verifier/src/qe_identity.rs
+++ b/verifier/src/qe_identity.rs
@@ -37,17 +37,20 @@
 
 #![allow(dead_code)]
 
-use crate::advisories::AdvisoryStatus;
-use crate::{Accessor, Advisories, Error, VerificationMessage, VerificationOutput, Verifier};
-use alloc::boxed::Box;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
+use crate::{
+    advisories::AdvisoryStatus, Accessor, Advisories, Error, VerificationMessage,
+    VerificationOutput, Verifier,
+};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt::Formatter;
 use der::DateTime;
 use mc_sgx_core_sys_types::sgx_attributes_t;
 use mc_sgx_core_types::{Attributes, IsvProductId, IsvSvn, MiscellaneousSelect, MrSigner};
-use p256::ecdsa::signature::Verifier as SignatureVerifier;
-use p256::ecdsa::{Signature, VerifyingKey};
+use p256::ecdsa::{signature::Verifier as SignatureVerifier, Signature, VerifyingKey};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
@@ -348,10 +351,8 @@ mod test {
     use alloc::{format, vec};
     use assert_matches::assert_matches;
     use der::DateTime;
-    use p256::ecdsa::signature::Signer;
-    use p256::ecdsa::{SigningKey, VerifyingKey};
-    use x509_cert::der::DecodePem;
-    use x509_cert::Certificate;
+    use p256::ecdsa::{signature::Signer, SigningKey, VerifyingKey};
+    use x509_cert::{der::DecodePem, Certificate};
     use yare::parameterized;
 
     fn qe_verifying_key() -> VerifyingKey {

--- a/verifier/src/qe_report_body.rs
+++ b/verifier/src/qe_report_body.rs
@@ -2,13 +2,14 @@
 
 //! Verification of a QE(Quoting Enclave) report body.
 
-use crate::qe_identity::{QeIdentity, TcbLevel};
-use crate::report_body::MrSignerKeyVerifier;
-use crate::struct_name::SpacedStructName;
 use crate::{
-    choice_to_status_message, Accessor, Advisories, AdvisoriesVerifier, AdvisoryStatus,
-    AttributesVerifier, IsvProductIdVerifier, MiscellaneousSelectVerifier, VerificationMessage,
-    VerificationOutput, Verifier, MESSAGE_INDENT,
+    choice_to_status_message,
+    qe_identity::{QeIdentity, TcbLevel},
+    report_body::MrSignerKeyVerifier,
+    struct_name::SpacedStructName,
+    Accessor, Advisories, AdvisoriesVerifier, AdvisoryStatus, AttributesVerifier,
+    IsvProductIdVerifier, MiscellaneousSelectVerifier, VerificationMessage, VerificationOutput,
+    Verifier, MESSAGE_INDENT,
 };
 use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
@@ -274,10 +275,11 @@ impl VerificationMessage<(IsvSvn, Option<TcbLevel>)> for QeIsvSvnVerifier {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::qe_identity::{SignedQeIdentity, Tcb};
-    use crate::VerificationTreeDisplay;
-    use alloc::format;
-    use alloc::string::ToString;
+    use crate::{
+        qe_identity::{SignedQeIdentity, Tcb},
+        VerificationTreeDisplay,
+    };
+    use alloc::{format, string::ToString};
     use mc_sgx_core_sys_types::sgx_report_body_t;
     use mc_sgx_core_types::AttributeFlags;
     use mc_sgx_dcap_types::Quote3;

--- a/verifier/src/report_body.rs
+++ b/verifier/src/report_body.rs
@@ -226,8 +226,7 @@ pub type ReportDataVerifier = MaskedVerifier<ReportData>;
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::struct_name::SpacedStructName;
-    use crate::{And, VerificationTreeDisplay};
+    use crate::{struct_name::SpacedStructName, And, VerificationTreeDisplay};
     use alloc::{format, string::ToString};
     use mc_sgx_core_sys_types::{
         sgx_attributes_t, sgx_cpu_svn_t, sgx_measurement_t, sgx_report_body_t, sgx_report_data_t,

--- a/verifier/src/tcb.rs
+++ b/verifier/src/tcb.rs
@@ -29,16 +29,15 @@
 
 #![allow(dead_code)]
 
-use crate::advisories::{Advisories, AdvisoryStatus};
-use crate::{Accessor, Error, VerificationMessage, VerificationOutput, Verifier};
-use alloc::boxed::Box;
-use alloc::string::String;
-use alloc::vec::Vec;
+use crate::{
+    advisories::{Advisories, AdvisoryStatus},
+    Accessor, Error, VerificationMessage, VerificationOutput, Verifier,
+};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::fmt::Formatter;
 use der::DateTime;
 use mc_sgx_dcap_types::{TcbInfo as PckTcb, COMPONENT_SVN_COUNT, FMSPC_SIZE};
-use p256::ecdsa::signature::Verifier as SignatureVerifier;
-use p256::ecdsa::{Signature, VerifyingKey};
+use p256::ecdsa::{signature::Verifier as SignatureVerifier, Signature, VerifyingKey};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
@@ -342,8 +341,7 @@ mod tests {
     use crate::VerificationTreeDisplay;
     use alloc::{format, vec};
     use assert_matches::assert_matches;
-    use p256::ecdsa::signature::Signer;
-    use p256::ecdsa::{SigningKey, VerifyingKey};
+    use p256::ecdsa::{signature::Signer, SigningKey, VerifyingKey};
     use x509_cert::{der::DecodePem, Certificate};
     use yare::parameterized;
 

--- a/verifier/src/x509.rs
+++ b/verifier/src/x509.rs
@@ -1,18 +1,22 @@
 // Copyright (c) 2023 The MobileCoin Foundation
 
 extern crate alloc;
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt::{Debug, Formatter};
+use der::{DateTime, Encode};
 
 use mbedtls::{
     alloc::List as MbedtlsList,
     hash::Type as HashType,
     pk::{EcGroupId, Type as PkType},
-    x509::{Certificate, Crl, KeyUsage, Profile},
+    x509::{Certificate, Crl, Profile},
 };
 
-use x509_cert::{der::Decode, Certificate as X509Certificate};
+use crate::{CertificateChainVerifier, CertificateChainVerifierError};
+use x509_cert::crl::CertificateList;
+use x509_cert::Certificate as X509Certificate;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -21,11 +25,60 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     /// An error occurred working with MbedTls: {0}
     MbedTls(mbedtls::Error),
+    /// An error occurred encoding to DER: {0}
+    Der(der::Error),
 }
 
 impl From<mbedtls::Error> for Error {
     fn from(src: mbedtls::Error) -> Self {
         Error::MbedTls(src)
+    }
+}
+
+impl From<der::Error> for Error {
+    fn from(src: der::Error) -> Self {
+        Error::Der(src)
+    }
+}
+
+impl From<Error> for CertificateChainVerifierError {
+    fn from(error: Error) -> Self {
+        match error {
+            // Any error (expired, revoked, etc) in certificate chain verification comes back as
+            // `X509CertVerifyFailed`
+            Error::MbedTls(mbedtls::Error::X509CertVerifyFailed) => {
+                CertificateChainVerifierError::SignatureVerification
+            }
+            _ => CertificateChainVerifierError::GeneralCertificateError,
+        }
+    }
+}
+
+/// A certificate chain verifier that uses MbedTls as the backend
+#[derive(Debug)]
+pub struct X509CertificateChainVerifier {
+    trust_anchor: TrustAnchor,
+}
+
+impl X509CertificateChainVerifier {
+    /// Create a new instance
+    pub fn new(trust_anchor: TrustAnchor) -> Self {
+        Self { trust_anchor }
+    }
+}
+
+impl CertificateChainVerifier for X509CertificateChainVerifier {
+    // Note: `_time` is ignored because MbedTls will call out to a system timer.
+    fn verify_certificate_chain<'a, 'b>(
+        &self,
+        certificate_chain: impl IntoIterator<Item = &'a X509Certificate>,
+        crls: impl IntoIterator<Item = &'b CertificateList>,
+        _time: DateTime,
+    ) -> core::result::Result<(), CertificateChainVerifierError> {
+        let unverified = UnverifiedCertChain::try_from_certificates(certificate_chain)
+            .map_err(|_| CertificateChainVerifierError::GeneralCertificateError)?;
+        let crls = CertificateRevocationList::try_from_crls(crls)?;
+        Ok(unverified.verify(&self.trust_anchor, crls)?)
     }
 }
 
@@ -72,7 +125,7 @@ impl TrustAnchor {
 /// This is mostly opaque meant to be used to verify and create a
 /// [`VerifiedCertChain`].
 #[derive(Clone)]
-pub struct UnverifiedCertChain(MbedtlsList<Certificate>);
+struct UnverifiedCertChain(MbedtlsList<Certificate>);
 
 impl Debug for UnverifiedCertChain {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
@@ -85,11 +138,7 @@ impl UnverifiedCertChain {
     ///
     /// # Errors
     /// `Error::MbedTls` if the certificate chain is not valid.
-    pub fn verify(
-        self,
-        trust_anchor: &TrustAnchor,
-        mut crl: CertificateRevocationList,
-    ) -> Result<VerifiedCertChain> {
+    fn verify(self, trust_anchor: &TrustAnchor, mut crl: CertificateRevocationList) -> Result<()> {
         let profile = Profile::new(
             vec![HashType::Sha256, HashType::Sha384, HashType::Sha512],
             // The note on `PkType::Ecdsa` is a lie:
@@ -107,34 +156,13 @@ impl UnverifiedCertChain {
             ],
             2048,
         );
-        Certificate::verify_with_profile(
+        Ok(Certificate::verify_with_profile(
             &self.0,
             &trust_anchor.0,
             Some(&mut crl.0),
             Some(&profile),
             None,
-        )?;
-        Ok(VerifiedCertChain(self.0))
-    }
-
-    /// Try to get a certificate chain from an iterator of PEM encoded strings
-    ///
-    /// # Errors
-    /// `Error::MbedTls` if one of the strings is not valid PEM certificate(s).
-    pub fn try_from_pem<'a, E, I>(pems: I) -> Result<Self>
-    where
-        I: IntoIterator<Item = &'a E>,
-        E: ToString + 'a + ?Sized,
-    {
-        let mut certs = MbedtlsList::<Certificate>::new();
-        for pem in pems.into_iter() {
-            let mut pem = pem.to_string();
-            // Null terminate for Mbedtls
-            pem.push('\0');
-            let cert = Certificate::from_pem(pem.as_bytes())?;
-            certs.push(cert);
-        }
-        Ok(Self(certs))
+        )?)
     }
 
     /// Try to get a certificate chain from an iterator of DER encoded byte
@@ -154,39 +182,35 @@ impl UnverifiedCertChain {
         }
         Ok(Self(certs))
     }
+
+    /// Try to get a certificate chain from an iterator of X509Certificates
+    ///
+    /// # Errors
+    /// `Error::MbedTls` if there is a problem decoding a certificate by mbedtls
+    /// `Error::Der` if there is an error converting a certificate to DER
+    pub fn try_from_certificates<'a, I>(certs: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = &'a X509Certificate>,
+    {
+        let certs = certs
+            .into_iter()
+            .map(|crl| crl.to_der())
+            .collect::<core::result::Result<Vec<_>, _>>()?;
+        Self::try_from_der(certs)
+    }
 }
 
 /// Certificate revocation list.
 #[derive(Debug)]
-pub struct CertificateRevocationList(Crl);
+struct CertificateRevocationList(Crl);
 
 impl CertificateRevocationList {
-    /// Try to get a set of certificate revocation lists from an iterator of
-    /// PEM encoded strings.
-    ///
-    /// # Errors
-    /// `Error::MbedTls` if one of the strings is not a valid PEM CRL.
-    pub fn try_from_pem<'a, E, I>(pems: I) -> Result<Self>
-    where
-        I: IntoIterator<Item = &'a E>,
-        E: ToString + 'a + ?Sized,
-    {
-        let mut crl = Crl::new();
-        for pem in pems.into_iter() {
-            let mut pem = pem.to_string();
-            // Null terminate for Mbedtls
-            pem.push('\0');
-            crl.push_from_pem(pem.as_bytes())?;
-        }
-        Ok(Self(crl))
-    }
-
     /// Try to get a set of certificate revocation lists from an iterator of
     /// DER encoded byte slices.
     ///
     /// # Errors
     /// `Error::MbedTls` if one of the slices is not a valid DER CRL.
-    pub fn try_from_der<E, I>(ders: I) -> Result<Self>
+    fn try_from_der<E, I>(ders: I) -> Result<Self>
     where
         I: IntoIterator<Item = E>,
         E: AsRef<[u8]>,
@@ -197,54 +221,34 @@ impl CertificateRevocationList {
         }
         Ok(Self(crl))
     }
-}
 
-/// A verified certificate chain.
-///
-/// See [`UnverifiedCertChain::verify`] for creating one.
-pub struct VerifiedCertChain(MbedtlsList<Certificate>);
-
-impl VerifiedCertChain {
-    /// Get the leaf certificate.
+    /// Try to get a set of certificate revocation lists from an iterator of `CertificateList`
     ///
-    /// Returns `None` if the chain is empty or only contains CA certificates.
-    ///
-    /// # Panics
-    /// If the leaf certificate is not valid DER. The leaf certificate was
-    /// loaded via an [`UnverifiedCertChain`] so it should be valid DER.
-    pub fn leaf(&self) -> Option<X509Certificate> {
-        for cert in self.0.iter() {
-            // Per [rfc5280](https://datatracker.ietf.org/doc/html/rfc5280)
-            // The `keyCertSign` bit is asserted for CA certificates, or non
-            // leaf certificates.
-            if cert.check_key_usage(KeyUsage::KEY_CERT_SIGN) {
-                continue;
-            }
-            return Some(X509Certificate::from_der(cert.as_der()).expect(
-                "Failed to parse leaf certificate that was able to load into a certificate chain",
-            ));
-        }
-        None
-    }
-}
-
-impl Debug for VerifiedCertChain {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "VerifiedCertChain{{...}}")
+    /// # Errors
+    /// `Error::MbedTls` if there is a problem decoding a CRL by mbedtls
+    /// `Error::Der` if there is an error converting a CRL to DER
+    fn try_from_crls<'a, I>(crls: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = &'a CertificateList>,
+    {
+        let crls = crls
+            .into_iter()
+            .map(|crl| crl.to_der())
+            .collect::<core::result::Result<Vec<_>, _>>()?;
+        Self::try_from_der(crls)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use x509_cert::der::DecodePem;
-    use yare::parameterized;
+    use der::{Decode, DecodePem};
 
     const LEAF_CERT: &str = include_str!("../data/tests/leaf_cert.pem");
     const PROCESSOR_CA: &str = include_str!("../data/tests/processor_ca.pem");
     const ROOT_CA: &str = include_str!("../data/tests/root_ca.pem");
-    const PROCESSOR_CRL: &str = include_str!("../data/tests/processor_crl.pem");
-    const ROOT_CRL: &str = include_str!("../data/tests/root_crl.pem");
+    const PROCESSOR_CRL: &[u8] = include_bytes!("../data/tests/processor_crl.der");
+    const ROOT_CRL: &[u8] = include_bytes!("../data/tests/root_crl.der");
 
     // common PKITs tests data
     const TRUST_ANCHOR_ROOT_CERTIFICATE: &[u8] =
@@ -281,32 +285,6 @@ mod test {
     }
 
     #[test]
-    fn cert_chain_from_one_pem_cert() {
-        let cert_chain =
-            UnverifiedCertChain::try_from_pem([LEAF_CERT]).expect("failed to parse cert chain");
-        // Counting manually, because `MbedtlsList` is a linked list without
-        // `len()` method.
-        let count = cert_chain.0.iter().count();
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn cert_chain_from_two_pem_certs() {
-        let cert_chain = UnverifiedCertChain::try_from_pem([LEAF_CERT, PROCESSOR_CA])
-            .expect("failed to parse cert chain");
-        let count = cert_chain.0.iter().count();
-        assert_eq!(count, 2);
-    }
-
-    #[test]
-    fn cert_chain_from_invalid_pem_cert() {
-        assert!(matches!(
-            UnverifiedCertChain::try_from_pem([&LEAF_CERT[1..]]),
-            Err(Error::MbedTls(_))
-        ));
-    }
-
-    #[test]
     fn cert_chain_from_one_der_cert() {
         let cert_chain = UnverifiedCertChain::try_from_der([TRUST_ANCHOR_ROOT_CERTIFICATE])
             .expect("failed to parse cert chain");
@@ -333,35 +311,56 @@ mod test {
 
     #[test]
     fn verify_valid_cert_chain() {
-        let cert_chain = UnverifiedCertChain::try_from_pem([LEAF_CERT, PROCESSOR_CA, ROOT_CA])
-            .expect("failed to parse cert chain");
+        let time = DateTime::from_unix_duration(Default::default())
+            .expect("failed to get UNIX EPOCH time");
+        let chain = [LEAF_CERT, PROCESSOR_CA, ROOT_CA]
+            .iter()
+            .map(|cert| X509Certificate::from_pem(cert).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_pem(ROOT_CA).expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_pem([ROOT_CRL, PROCESSOR_CRL])
-            .expect("failed to parse CRL");
-        assert!(cert_chain.verify(&trust_anchor, crl).is_ok());
+        let crls = [ROOT_CRL, PROCESSOR_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
+        assert!(verifier
+            .verify_certificate_chain(chain.iter(), crls.iter(), time)
+            .is_ok());
     }
 
     #[test]
     fn invalid_cert_chain() {
-        let cert_chain = UnverifiedCertChain::try_from_pem([LEAF_CERT, ROOT_CA])
-            .expect("failed to parse cert chain");
+        let chain = [LEAF_CERT, ROOT_CA]
+            .iter()
+            .map(|cert| X509Certificate::from_pem(cert).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_pem(ROOT_CA).expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_pem([ROOT_CRL, PROCESSOR_CRL])
-            .expect("failed to parse CRL");
-        assert!(matches!(
-            cert_chain.verify(&trust_anchor, crl),
-            Err(Error::MbedTls(_))
-        ));
+        let crls = [ROOT_CRL, PROCESSOR_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
+        assert_eq!(
+            verifier.verify_certificate_chain(chain.iter(), crls.iter(), DateTime::INFINITY),
+            Err(CertificateChainVerifierError::SignatureVerification)
+        );
     }
 
     #[test]
     fn unordered_cert_chain_succeeds() {
-        let cert_chain = UnverifiedCertChain::try_from_pem([PROCESSOR_CA, ROOT_CA, LEAF_CERT])
-            .expect("failed to parse cert chain");
+        let chain = [PROCESSOR_CA, ROOT_CA, LEAF_CERT]
+            .iter()
+            .map(|cert| X509Certificate::from_pem(cert).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_pem(ROOT_CA).expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_pem([ROOT_CRL, PROCESSOR_CRL])
-            .expect("failed to parse CRL");
-        assert!(cert_chain.verify(&trust_anchor, crl).is_ok());
+        let crls = [ROOT_CRL, PROCESSOR_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
+        assert!(verifier
+            .verify_certificate_chain(chain.iter(), crls.iter(), DateTime::INFINITY)
+            .is_ok());
     }
 
     // The below tests are from the
@@ -382,12 +381,16 @@ mod test {
             NO_CRL_CA_CERT,
             TRUST_ANCHOR_ROOT_CERTIFICATE,
         ];
-        let cert_chain =
-            UnverifiedCertChain::try_from_der(&ders).expect("failed to parse cert chain");
+        let chain = ders
+            .iter()
+            .map(|der| X509Certificate::from_der(der).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_der(TRUST_ANCHOR_ROOT_CERTIFICATE)
             .expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_der([TRUST_ANCHOR_ROOT_CRL])
-            .expect("failed to parse CRL");
+        let crls = [TRUST_ANCHOR_ROOT_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
 
         // As the name suggests, this test should fail, however Mbedtls doesn't
         // seem to conform to the RFC,
@@ -403,7 +406,10 @@ mod test {
         // <https://github.com/mobilecoinfoundation/rust-mbedtls/blob/6d8fe323a3292f87a6bce4b35963d47139a583f9/mbedtls-sys/vendor/library/x509_crt.c#L2337>
         //
         // > Skip validation if no CRL for the given CA is present.
-        assert_eq!(cert_chain.verify(&trust_anchor, crl).is_ok(), true);
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
+        assert!(verifier
+            .verify_certificate_chain(chain.iter(), crls.iter(), DateTime::INFINITY)
+            .is_ok());
     }
 
     #[test]
@@ -420,21 +426,22 @@ mod test {
             GOOD_CA_CERT,
             TRUST_ANCHOR_ROOT_CERTIFICATE,
         ];
-        let cert_chain =
-            UnverifiedCertChain::try_from_der(&ders).expect("failed to parse cert chain");
+        let chain = ders
+            .iter()
+            .map(|der| X509Certificate::from_der(der).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_der(TRUST_ANCHOR_ROOT_CERTIFICATE)
             .expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_der([
-            REVOKED_SUB_CA_CRL,
-            GOOD_CA_CRL,
-            TRUST_ANCHOR_ROOT_CRL,
-        ])
-        .expect("failed to parse CRL");
+        let crls = [REVOKED_SUB_CA_CRL, GOOD_CA_CRL, TRUST_ANCHOR_ROOT_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
 
-        assert!(matches!(
-            cert_chain.verify(&trust_anchor, crl),
-            Err(Error::MbedTls(_))
-        ));
+        assert_eq!(
+            verifier.verify_certificate_chain(chain.iter(), crls.iter(), DateTime::INFINITY),
+            Err(CertificateChainVerifierError::SignatureVerification)
+        );
     }
 
     #[test]
@@ -446,17 +453,22 @@ mod test {
             GOOD_CA_CERT,
             TRUST_ANCHOR_ROOT_CERTIFICATE,
         ];
-        let cert_chain =
-            UnverifiedCertChain::try_from_der(&ders).expect("failed to parse cert chain");
+        let chain = ders
+            .iter()
+            .map(|der| X509Certificate::from_der(der).expect("failed to parse cert"))
+            .collect::<Vec<_>>();
         let trust_anchor = TrustAnchor::try_from_der(TRUST_ANCHOR_ROOT_CERTIFICATE)
             .expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_der([GOOD_CA_CRL, TRUST_ANCHOR_ROOT_CRL])
-            .expect("failed to parse CRL");
+        let crls = [GOOD_CA_CRL, TRUST_ANCHOR_ROOT_CRL]
+            .iter()
+            .map(|crl| CertificateList::from_der(crl).expect("failed to parse CRL"))
+            .collect::<Vec<_>>();
+        let verifier = X509CertificateChainVerifier::new(trust_anchor);
 
-        assert!(matches!(
-            cert_chain.verify(&trust_anchor, crl),
-            Err(Error::MbedTls(_))
-        ));
+        assert_eq!(
+            verifier.verify_certificate_chain(chain.iter(), crls.iter(), DateTime::INFINITY),
+            Err(CertificateChainVerifierError::SignatureVerification)
+        );
     }
 
     #[test]
@@ -471,39 +483,5 @@ mod test {
             ]),
             Err(Error::MbedTls(_))
         ));
-    }
-
-    #[test]
-    fn no_leaf_certificate_available() {
-        let cert_chain = UnverifiedCertChain::try_from_pem([PROCESSOR_CA, ROOT_CA])
-            .expect("failed to parse cert chain");
-        let trust_anchor = TrustAnchor::try_from_pem(ROOT_CA).expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_pem([ROOT_CRL]).expect("failed to parse CRL");
-
-        let verified_cert_chain = cert_chain
-            .verify(&trust_anchor, crl)
-            .expect("failed to verify cert chain");
-
-        assert_eq!(verified_cert_chain.leaf(), None);
-    }
-
-    #[parameterized(
-        first = { &[LEAF_CERT, PROCESSOR_CA, ROOT_CA] },
-        middle = { &[PROCESSOR_CA, LEAF_CERT, ROOT_CA] },
-        last = { &[ROOT_CA, PROCESSOR_CA, LEAF_CERT] },
-    )]
-    fn leaf_certificate(pems: &[&str]) {
-        let cert_chain =
-            UnverifiedCertChain::try_from_pem(pems).expect("failed to parse cert chain");
-        let trust_anchor = TrustAnchor::try_from_pem(ROOT_CA).expect("failed to parse root cert");
-        let crl = CertificateRevocationList::try_from_pem([ROOT_CRL]).expect("failed to parse CRL");
-
-        let verified_cert_chain = cert_chain
-            .verify(&trust_anchor, crl)
-            .expect("failed to verify cert chain");
-
-        let expected_certificate =
-            X509Certificate::from_pem(LEAF_CERT).expect("failed to parse PEM");
-        assert_eq!(verified_cert_chain.leaf(), Some(expected_certificate));
     }
 }


### PR DESCRIPTION
A `CertificateChainVerifier` implementation is now available using
mbedtls. This implementation is behind the `x509` feature flag.

