### PR TITLE
Fix logic to update README of anchor crate.

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -45,4 +45,5 @@ pre-release-replacements = [
     { file = "../CHANGELOG.md", search = "ReleaseDate", replace= "{{date}}", min = 1 },
     { file = "../CHANGELOG.md", search = "<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly = 1 },
     { file = "../CHANGELOG.md", search = "<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/mobilecoinfoundation/attestation/compare/{{tag_name}}...HEAD", exactly = 1 },
+    { file = "README.md", search = "mc-attestation-[a-z-]+/[0-9.]+", replace = "{{crate_name}}/{{version}}" },
 ]


### PR DESCRIPTION
When using `cargo release` one crate in a repository has settings on
how to update the CHANGELOG. This is the anchor crate. Since this crate
has the Cargo.toml entry `[package.metadata.release]` it will not look
at the entry in the root `Cargo.toml`. The common settings of updating
the README must be repeated in the anchor crates
`[package.metadata.release]`.

