### PR TITLE
Add `Serialize` and `Deserialize` to `Error`

### DIFF
--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -60,3 +60,26 @@ impl From<TcbError> for Error {
         Error::Quote3TcbInfo(e)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[test]
+    fn serde_error_to_string() {
+        let bad_json = "not json";
+        let e = serde_json::from_str::<serde_json::Value>(bad_json).unwrap_err();
+        let serde_error_message = e.to_string();
+        let err = Error::from(e);
+        assert_matches!(err, Error::Serde(message) if message.contains(&serde_error_message));
+    }
+
+    #[test]
+    fn der_error_to_string() {
+        let e = der::Error::incomplete(1u8.into());
+        let der_error_message = e.to_string();
+        let err = Error::from(e);
+        assert_matches!(err, Error::Der(message) if message.contains(&der_error_message));
+    }
+}

--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -2,15 +2,17 @@
 
 //! Errors that can occur during verification
 
+use alloc::string::{String, ToString};
 use mc_sgx_dcap_types::TcbError;
+use serde::{Deserialize, Serialize};
 
 /// Error working with quote evidence
-#[derive(displaydoc::Display, Debug)]
+#[derive(displaydoc::Display, Debug, Clone, Serialize, Deserialize)]
 pub enum Error {
     /// Error converting from DER {0}
-    Der(der::Error),
+    Der(String),
     /// Error parsing TCB(Trusted Computing Base) json info: {0}
-    Serde(serde_json::Error),
+    Serde(String),
     /// Error decoding the signature in the TCB data
     SignatureDecodeError,
     /// Error verifying the signature
@@ -43,13 +45,13 @@ pub enum Error {
 
 impl From<der::Error> for Error {
     fn from(e: der::Error) -> Self {
-        Error::Der(e)
+        Error::Der(e.to_string())
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
-        Error::Serde(e)
+        Error::Serde(e.to_string())
     }
 }
 


### PR DESCRIPTION
Any error that is meant out be propagated out of an enclave needs to
be able to be serialized and deserialized from the trusted side into the
untrusted side.
    
`Clone` was also added as the changes needed for `Serialize` and
`Deserialize` made it possible for the error to be cloneable.