### PR TITLE
Add `PartialEq` to `Error`

### DIFF
--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -7,7 +7,7 @@ use mc_sgx_dcap_types::TcbError;
 use serde::{Deserialize, Serialize};
 
 /// Error working with quote evidence
-#[derive(displaydoc::Display, Debug, Clone, Serialize, Deserialize)]
+#[derive(displaydoc::Display, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Error {
     /// Error converting from DER {0}
     Der(String),


### PR DESCRIPTION
Adding `PartialEq` to `Error` to make it more ergonomic for
consumers. Since the `Error` type implements `Serialize` and
`Deserialize` all of the error variants are simple types that implement
equivalence.
