### PR TITLE
Remove bumping `codecov-action` to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,7 @@ jobs:
       - run: |
           cargo llvm-cov --locked --all-features --workspace --lcov \
             --output-path lcov.info
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         with:
           files: lcov.info
 


### PR DESCRIPTION
Dependabot had bumped the codecov action to v4 and it passed CI, but now
it doesn't. I'm guessing there was a mistake where they removed v4. At
the time of this PR there are v4-beta tags.
