### PR TITLE
Use `lockfile-only` for cargo dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,8 +7,7 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(deps)"
-    reviewers:
-      - "mobilecoinfoundation/coredev"
+    versioning-strategy: lockfile-only
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -16,8 +15,6 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(deps)"
-    reviewers:
-      - "mobilecoinfoundation/coredev"
     ignore:
       # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
       # by rust-toolchain. Using a branch name will cause dependabot to suggest


### PR DESCRIPTION
Previously the dependabot for cargo was using `auto` which would update
both the manifest, `Cargo.toml` files and the `Cargo.lock` file. Since
this repository is for library crates, we only want to update the lock
file that people develop with. We don't want to update the manifest file
and force consumers to update unnecessarily.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
