### PR TITLE
Bump nightly CI runs to 10-01-2023

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,6 @@ name: ci
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
-  # This works around `dtolnay/rust-toolchain@master` it defaults to "sparse"
-  # when 1.68 is used, but the current nightly version (nightly-2023-01-04) is
-  # before the official support that doesn't use `-Z sparse`
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "git"
 
 jobs:
   # TODO: Fix automatically
@@ -34,92 +30,6 @@ jobs:
           globs: "**/*.md"
       # FIXME: Add yamllint problem matcher
       - run: yamllint -s .
-
-  crev:
-    runs-on: ubuntu-22.04
-    needs:
-      - lint
-    # TODO: once we have enough reviews, make this a required check
-    continue-on-error: true
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        continue-on-error: false
-        with:
-          path: |
-            Cargo.lock
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
-      - uses: taiki-e/install-action@v2
-        with:
-          # Pinning to 0.23 due to
-          # https://github.com/crev-dev/cargo-crev/issues/598
-          tool: cargo-crev@0.23
-      - name: Configure Crev
-        run: |
-          cargo crev trust \
-            --level high \
-            --no-commit https://github.com/mobilecoinfoundation/crev-proofs
-      - name: Run Cargo Crev
-        id: cargo-crev
-        run: |
-          set +e
-          export MARKER=$RANDOM
-          echo "UNREVIEWED_DEPENDENCIES<<EOF${MARKER}" >> $GITHUB_OUTPUT
-          # GH does not like colors in crev output
-          export TERM=xterm-mono
-          # - Get a TSV-formatted table of dependencies without reviews
-          # - Skip any "local" dependencies
-          # - Convert the table to GHF markdown
-          # - Sort descending by the "LoC" value (first column preceeds first
-          #   pipe)
-
-          cargo generate-lockfile --offline
-          cargo crev crate verify \
-              --for-id vMr-9g5KzKQLsCpkp1tc8o7AR6a0OptjOICjf7NMyHE \
-              --show-all \
-              --skip-indirect \
-              --skip-verified \
-              --skip-known-owners \
-              --trust medium \
-              --thoroughness medium \
-              --understanding medium \
-              --redundancy 2 | \
-            grep -v '^local ' | \
-            awk '{
-              printf("| %s | %s | %s | %s | %s | %s | %s |\n",
-                     $14, $15, $2, $10, $11, $12, $13)
-            }' | \
-            sort -t\| -n -k5 | \
-            tee /dev/stderr >> $GITHUB_OUTPUT
-          STATUS=$?
-          echo "EOF${MARKER}" >> $GITHUB_OUTPUT
-
-          set -e
-
-          # TODO: When we're ready to make this required
-          # exit $STATUS
-          exit 0
-        shell: bash
-      - uses: mshick/add-pr-comment@v2
-        with:
-          # yamllint disable rule:line-length
-          message: |
-            #### :x: Unreviewed dependencies found
-
-            | Crate | Version | Reviews (N/2) | LoC | Left-Pad Index | Geiger | Flags |
-            | ----- | ------- | ------------- | --- | -------------- | ------ | ----- |
-            ${{ steps.cargo-crev.outputs.UNREVIEWED_DEPENDENCIES }}
-          # yamllint enable rule:line-length
 
   deny:
     runs-on: ubuntu-22.04
@@ -187,7 +97,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-10-01
     steps:
       - uses: actions/checkout@v4
         with:
@@ -207,7 +117,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-10-01
     steps:
       - uses: actions/checkout@v4
         with:
@@ -259,35 +169,3 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-
-  notify:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && failure()
-    needs:
-      - lint
-      - deny
-      - sort
-      - clippy
-      - build
-      - test
-      - doc
-      - coverage
-    steps:
-      - name: Notify Discord on failure
-        uses: sarisia/actions-status-discord@v1
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          username: "Github Actions"
-          status: Failure
-          color: 0xff0000
-          nodetail: true
-          # yamllint disable rule:line-length
-          title: "${{ github.repository }} ${{ github.workflow }} has failed on ${{ github.event_name }} to ${{ github.ref_name }}"
-          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          description: >
-            [`@${{ github.actor }}`](${{ github.server_url }}/${{ github.actor }})
-            was the last one to touch
-            [that repository](${{ github.server_url }}/${{ github.repository }}),
-            is all I'm saying.
-          avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
-          # yamllint enable rule:line-length


### PR DESCRIPTION
This matches the nightly currently used by the main consumer of this
crate,
<https://github.com/mobilecoinfoundation/mobilecoin/blob/39fbbdaae314c5696f44bfb4df1c46d75ce46aeb/rust-toolchain#L2>
